### PR TITLE
Fix chrome hint

### DIFF
--- a/404.html
+++ b/404.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -181,7 +176,7 @@ Locating webpage  [FAILED]
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/archive.html
+++ b/archive.html
@@ -17,7 +17,7 @@
     <meta name="keywords" content="babun, shell, cygwin, console">
     <meta name="generator" content="JBake">
 
-    <!-- null -->
+    <!--  -->
 
     <!-- Le styles -->
     <link href="css/bootstrap.min.css" rel="stylesheet">
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -203,7 +198,7 @@
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog.html
+++ b/blog.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -517,7 +512,7 @@ If you know what you are doing add '--force' flag to proceed.
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog_posts/001_rel_1.0.0.html
+++ b/blog_posts/001_rel_1.0.0.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -163,7 +158,7 @@
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog_posts/002_rel_1.0.1.html
+++ b/blog_posts/002_rel_1.0.1.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -229,7 +224,7 @@
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog_posts/003_rel_1.1.0.html
+++ b/blog_posts/003_rel_1.1.0.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -306,7 +301,7 @@ If you know what you are doing add '--force' flag to proceed.
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog_posts/004_rel_1.1.1.html
+++ b/blog_posts/004_rel_1.1.1.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -165,7 +160,7 @@
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/blog_posts/005_rel_1.2.0.html
+++ b/blog_posts/005_rel_1.2.0.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -259,7 +254,7 @@ It makes sure that all footprints left by plugins (such as registry entries) are
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/development.html
+++ b/development.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -451,7 +446,7 @@ The folder structure looks like this:</p>
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/faq.html
+++ b/faq.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -673,7 +668,7 @@ see <a href="https://github.com/babun/babun/issues/191">Issue 191</a></p>
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -719,7 +714,7 @@ export LC_ALL="en_US.UTF-8"
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>

--- a/pagesource/templates/banner.gsp
+++ b/pagesource/templates/banner.gsp
@@ -15,12 +15,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           <%include "social.gsp"%>
         </div>

--- a/screenshots.html
+++ b/screenshots.html
@@ -106,12 +106,6 @@
               </a>              
           </p>
 
-          <script>
-            var is_chrome = navigator.userAgent.toLowerCase().indexOf('chrome') > -1;   
-            if (is_chrome) {
-              document.write('<font color="#BC451A">Note: Chrome currently blocks the downloaded file. Please download using differen browser until the <a href="https://github.com/babun/babun/issues/464" target="_blank"><u>problem</u></a> is resolved.</font>');
-            }        
-          </script>
           
           
 <div class="container social">
@@ -134,6 +128,7 @@
         </div>
       </div>
     </div>
+
 
 <div class="container">
 
@@ -243,7 +238,7 @@
     <div id="footer">
       <div class="container">
         <p class="muted credit">
-          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.3.2</a>.
+          &copy; Babun Team 2015 | Babun is licensed under the Apache License v2. | Mixed with <a href="http://getbootstrap.com/">Bootstrap v3.1.1</a> | Baked with <a href="http://jbake.org">JBake v2.4.0</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Reverts changes introduced to fix babun/babun/issues/464 as the issue seems resolved now (see most recent comments).

I hope the contribution 'chain' is correct – the instructions on modifying the website aren't entirely clear (this is neither a blog post edit, nor was there mention of the removed code in any of the files in the [adoc](https://github.com/babun/babun/tree/master/babun-doc/adoc) directory in the babun repo).

I originally changed the `banner.gsp` file, then regenerated the pages with `jbake -s` (the instructions for that could also be improved btw. as `jbake -s` defaults to creating an `output` directory while here, all the output files go into the parent directory).
